### PR TITLE
ci: Add release workflow triggered on new tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,28 +7,21 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs: 
-  get-version:
-    name: resolve version
-    runs-on: ubuntu-latest
-    outputs:
-      result: ${{ steps.get_version.outputs.version }}
-    steps:
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
-  
   create-release:
     name: create release
     runs-on: ubuntu-latest
-    needs: 
-      - get-version
     outputs: 
       upload-url: ${{ steps.create_release.outputs.upload_url }}
+      version: ${{ steps.get_version.outputs.version }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+
       - name: "Build Changelog"
         id: changelog
         uses: mikepenz/release-changelog-builder-action@v1
@@ -39,9 +32,9 @@ jobs:
         uses: actions/create-release@v1
         id: create_release
         with:
-          draft: true
+          draft: false
           prerelease: false
-          release_name: Policy Tester ${{ needs.get-version.outputs.result }}
+          release_name: Policy Tester ${{ steps.get_version.outputs.version }}
           tag_name: ${{ github.ref }}
           body: |
             ${{ steps.changelog.outputs.changelog }}
@@ -53,7 +46,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: 
       - create-release
-      - get-version
     strategy:
       matrix:
         include:
@@ -74,7 +66,7 @@ jobs:
           export GOARCH=${{ matrix.goarch }}
           export GOOS=${{ matrix.goos }}
           go build -o bin/ .
-          zip -r -j bin/policy-tester.${{ needs.get-version.outputs.result }}.${{ matrix.goos }}-${{ matrix.goarch }}.zip bin/
+          zip -r -j bin/policy-tester.${{ needs.create-release.outputs.version }}.${{ matrix.goos }}-${{ matrix.goarch }}.zip bin/
       
       - name: upload ${{ matrix.goos }} artifact
         uses: actions/upload-release-asset@v1
@@ -82,6 +74,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ needs.create-release.outputs.upload-url }}
-          asset_path: cmd/policyTester/bin/policy-tester.${{ needs.get-version.outputs.result }}.${{ matrix.goos }}-${{ matrix.goarch }}.zip
-          asset_name: policy-tester.${{ needs.get-version.outputs.result }}.${{ matrix.goos }}-${{ matrix.goarch }}.zip
+          asset_path: cmd/policyTester/bin/policy-tester.${{ needs.create-release.outputs.version }}.${{ matrix.goos }}-${{ matrix.goarch }}.zip
+          asset_name: policy-tester.${{ needs.create-release.outputs.version }}.${{ matrix.goos }}-${{ matrix.goarch }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: 'Release'
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs: 
+  get-version:
+    name: resolve version
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+  
+  create-release:
+    name: create release
+    runs-on: ubuntu-latest
+    needs: 
+      - get-version
+    outputs: 
+      upload-url: ${{ steps.create_release.outputs.upload_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: "Build Changelog"
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: new release
+        uses: actions/create-release@v1
+        id: create_release
+        with:
+          draft: true
+          prerelease: false
+          release_name: Policy Tester ${{ needs.get-version.outputs.result }}
+          tag_name: ${{ github.ref }}
+          body: |
+            ${{ steps.changelog.outputs.changelog }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  build:
+    name: build tool binaries
+    runs-on: ubuntu-latest
+    needs: 
+      - create-release
+      - get-version
+    strategy:
+      matrix:
+        include:
+          - {goos: "linux", goarch: "amd64"}
+          - {goos: "windows", goarch: "amd64"}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+      
+      - name: Build for ${{ matrix.goos }}
+        working-directory: cmd/policyTester
+        run: |
+          export GOARCH=${{ matrix.goarch }}
+          export GOOS=${{ matrix.goos }}
+          go build -o bin/ .
+          zip -r -j bin/policy-tester.${{ needs.get-version.outputs.result }}.${{ matrix.goos }}-${{ matrix.goarch }}.zip bin/
+      
+      - name: upload ${{ matrix.goos }} artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload-url }}
+          asset_path: cmd/policyTester/bin/policy-tester.${{ needs.get-version.outputs.result }}.${{ matrix.goos }}-${{ matrix.goarch }}.zip
+          asset_name: policy-tester.${{ needs.get-version.outputs.result }}.${{ matrix.goos }}-${{ matrix.goarch }}.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
# Description
Adds automated release creation whenever a tag is created.

## Motivation and Context
Automatically create tool binaries in order to make it easily usable from anywhere.

## Breaking Changes
None.

## How Has This Been Tested?
Tested on forked repo.